### PR TITLE
Restore thumbs centering (fixes #14)

### DIFF
--- a/BaseImage.php
+++ b/BaseImage.php
@@ -194,13 +194,15 @@ class BaseImage
         $thumb = static::getImagine()->create($thumbnailBox, new Color(static::$thumbnailBackgroundColor, static::$thumbnailBackgroundAlpha));
 
         // calculate points
+        $size = $img->getSize();
+
         $startX = 0;
         $startY = 0;
-        if ($sourceBox->getWidth() < $width) {
-            $startX = ceil($width - $sourceBox->getWidth()) / 2;
+        if ($size->getWidth() < $width) {
+            $startX = ceil($width - $size->getWidth()) / 2;
         }
-        if ($sourceBox->getHeight() < $height) {
-            $startY = ceil($height - $sourceBox->getHeight()) / 2;
+        if ($size->getHeight() < $height) {
+            $startY = ceil($height - $size->getHeight()) / 2;
         }
 
         $thumb->paste($img, new Point($startX, $startY));

--- a/BaseImage.php
+++ b/BaseImage.php
@@ -190,12 +190,20 @@ class BaseImage
 
         $img = $img->thumbnail($thumbnailBox, $mode);
 
+        if ($mode == ManipulatorInterface::THUMBNAIL_OUTBOUND) {
+            return $img;
+        }
+
+        $size = $img->getSize();
+
+        if ($size->getWidth() == $width && $size->getHeight() == $height) {
+            return $img;
+        }
+
         // create empty image to preserve aspect ratio of thumbnail
         $thumb = static::getImagine()->create($thumbnailBox, new Color(static::$thumbnailBackgroundColor, static::$thumbnailBackgroundAlpha));
 
         // calculate points
-        $size = $img->getSize();
-
         $startX = 0;
         $startY = 0;
         if ($size->getWidth() < $width) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #14 

…ne/issues/14)

Bug was introduced in https://github.com/yiisoft/yii2-imagine/commit/d87e6a0d1adfd6fa5ef49c18228b2fc9bca04299

Start X and Y for centering shoud be calculated from already resized image, not source image.