### PR TITLE
Fix imagine constraint to allow dev-develop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "yiisoft/yii2": "~2.0.0",
-        "imagine/imagine": "~0.6.0"
+        "imagine/imagine": "~0.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

```
{
    "name": "my-project",
    "type": "project",
    "minimum-stability": "stable",
    "require": {
        ...
        "yiisoft/yii2-imagine": "dev-master",
        "imagine/imagine": "dev-develop",
         ...
      }
}
```

> Your requirements could not be resolved to an installable set of packages.

>  Problem 1
>    - Installation request for yiisoft/yii2-imagine dev-master -> satisfiable by yiisoft/yii2-imagine[dev-master].
>    - yiisoft/yii2-imagine dev-master requires imagine/imagine ~0.6.0 -> satisfiable by imagine/imagine[0.6.2, v0.6.0, v0.6.1, v0.6.3] but these conflict with your requirements or minimum-stability.