### PR TITLE
Thumbnail allow upscaling

### DIFF
--- a/BaseImage.php
+++ b/BaseImage.php
@@ -212,9 +212,12 @@ class BaseImage
      * @param int $width the width in pixels to create the thumbnail
      * @param int $height the height in pixels to create the thumbnail
      * @param string $mode mode of resizing original image to use in case both width and height specified
+     * @param bool $allowUpscaling should the image be upscaled if needed
      * @return ImageInterface
+     *
+     * @since 2.1.1 Added the $allowUpscaling argument.
      */
-    public static function thumbnail($image, $width, $height, $mode = ManipulatorInterface::THUMBNAIL_OUTBOUND)
+    public static function thumbnail($image, $width, $height, $mode = ManipulatorInterface::THUMBNAIL_OUTBOUND, $allowUpscaling = false)
     {
         $img = self::ensureImageInterfaceInstance($image);
 
@@ -223,12 +226,16 @@ class BaseImage
         $thumbnailBox = static::getThumbnailBox($sourceBox, $width, $height);
 
         if (self::isUpscaling($sourceBox, $thumbnailBox)) {
-            return $img->copy();
+            if ($allowUpscaling === false) {
+                return $img->copy();
+            } else {
+                $img = self::resize($image, $width, $height, true, true);
+            }
         }
 
         $img = $img->thumbnail($thumbnailBox, $mode);
 
-        if ($mode == ManipulatorInterface::THUMBNAIL_OUTBOUND) {
+        if ($allowUpscaling === false && $mode == ManipulatorInterface::THUMBNAIL_OUTBOUND) {
             return $img;
         }
 

--- a/BaseImage.php
+++ b/BaseImage.php
@@ -215,7 +215,7 @@ class BaseImage
      * @param bool $allowUpscaling should the image be upscaled if needed
      * @return ImageInterface
      *
-     * @since 2.1.1 Added the $allowUpscaling argument.
+     * @since 2.2.0 Added the $allowUpscaling argument.
      */
     public static function thumbnail($image, $width, $height, $mode = ManipulatorInterface::THUMBNAIL_OUTBOUND, $allowUpscaling = false)
     {
@@ -283,7 +283,7 @@ class BaseImage
      * @param bool $allowUpscaling should the image be upscaled if needed
      * @return ImageInterface
      *
-     * @since 2.1.1
+     * @since 2.2.0
      */
     public static function resize($image, $width, $height, $keepAspectRatio = true, $allowUpscaling = false)
     {
@@ -422,7 +422,7 @@ class BaseImage
      * @param bool $keepAspectRatio should we keep aspect ratio even if both with and height are set
      * @return BoxInterface new image box
      *
-     * @since 2.1.1
+     * @since 2.2.0
      */
     protected static function getBox(BoxInterface $sourceBox, $width, $height, $keepAspectRatio = true)
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 imagine extension Change Log
 -----------------------
 
 - Enh #22: Added method `Image::resize()` to ease resizing images to fit certain dimensions. (Renkas)
+- Enh #28: Added `$allowUpscaling` argument to `Image::thumbnail()` so it would be possible to always have thumbnail with fixed dimensions. (Renkas)
 
 
 2.1.0 November 3, 2016

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Yii Framework 2 imagine extension Change Log
 ================================================
 
-2.1.1 under development
+2.2.0 under development
 -----------------------
 
 - Enh #22: Added method `Image::resize()` to ease resizing images to fit certain dimensions. (Renkas)

--- a/tests/AbstractImageTest.php
+++ b/tests/AbstractImageTest.php
@@ -112,6 +112,17 @@ abstract class AbstractImageTest extends TestCase
 
         $this->assertEquals(234, $img->getSize()->getWidth());
         $this->assertEquals(120, $img->getSize()->getHeight());
+
+        // Image should be upscaled regardless of the mode.
+        $img = Image::thumbnail($this->imageFile, 1000, 1000, ImageInterface::THUMBNAIL_OUTBOUND, true);
+
+        $this->assertEquals(1000, $img->getSize()->getWidth());
+        $this->assertEquals(1000, $img->getSize()->getHeight());
+
+        $img = Image::thumbnail($this->imageFile, 1000, 1000, ImageInterface::THUMBNAIL_INSET, true);
+
+        $this->assertEquals(1000, $img->getSize()->getWidth());
+        $this->assertEquals(1000, $img->getSize()->getHeight());
     }
 
     /**


### PR DESCRIPTION
Added `$allowUpscaling` argument to `Image::thumbnail()` so it would be possible to always have thumbnail with fixed dimensions.

Fixes #28 